### PR TITLE
[WIP] Allow the use of an Arena for allocating Docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pretty"
-version = "0.0.7"
+version = "0.1.0"
 authors = [ "Jonathan Sterling <jon@jonmsterling.com>", "Darin Morrison <darinmorrison+git@gmail.com>" ]
 description = "Wadler-style pretty-printing combinators in Rust"
 documentation = "http://freebroccolo.github.io/pretty.rs/doc/pretty/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ path = "examples/trees.rs"
 
 [dependencies]
 typed-arena = "1.2.0"
+
+[dev-dependencies]
+tempfile = "2.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ path = "src/pretty/lib.rs"
 doc  = false
 name = "trees"
 path = "examples/trees.rs"
+
+
+[dependencies]
+typed-arena = "1.2.0"

--- a/benches/trees.rs
+++ b/benches/trees.rs
@@ -2,33 +2,51 @@
 
 extern crate test;
 extern crate pretty;
+extern crate typed_arena;
+
 use trees::{
     Tree,
 };
 
+use pretty::BoxAllocator;
+
+use typed_arena::Arena;
+
 #[path="../examples/trees.rs"]
 mod trees;
 
+macro_rules! bench_trees {
+    ($b: expr, $allocator: expr) => {{
+        let b = $b;
+        let allocator = $allocator;
+        let bbbbbbs =
+            [ Tree::node("ccc")
+            , Tree::node("dd")
+            ];
+        let ffffs =
+            [ Tree::node("gg")
+            , Tree::node("hhh")
+            , Tree::node("ii")
+            ];
+        let aaas =
+            [ Tree::node_with_forest("bbbbbb", &bbbbbbs)
+            , Tree::node("eee")
+            , Tree::node_with_forest("ffff", &ffffs)
+            ];
+        let example = Tree::node_with_forest("aaa", &aaas);
+        let mut out = std::io::sink();
+        let task = || {
+            example.pretty(&allocator).1.render(70, &mut out).unwrap();
+        };
+        b.iter(task);
+    }}
+}
+
 #[bench]
-fn bench(b: &mut test::Bencher) -> () {
-    let bbbbbbs =
-        [ Tree::node("ccc")
-        , Tree::node("dd")
-        ];
-    let ffffs =
-        [ Tree::node("gg")
-        , Tree::node("hhh")
-        , Tree::node("ii")
-        ];
-    let aaas =
-        [ Tree::node_with_forest("bbbbbb", &bbbbbbs)
-        , Tree::node("eee")
-        , Tree::node_with_forest("ffff", &ffffs)
-        ];
-    let example = Tree::node_with_forest("aaa", &aaas);
-    let mut out = std::io::sink();
-    let task = || {
-        example.pretty().render(70, &mut out).unwrap();
-    };
-    b.iter(task);
+fn bench_box(b: &mut test::Bencher) -> () {
+    bench_trees!(b, BoxAllocator)
+}
+#[bench]
+fn bench_arena(b: &mut test::Bencher) -> () {
+    bench_trees!(b, Arena::new())
 }

--- a/benches/trees.rs
+++ b/benches/trees.rs
@@ -23,7 +23,6 @@ macro_rules! bench_trees {
     ($b: expr, $out: expr, $allocator: expr, $size: expr) => {{
         let arena = Arena::new();
         let b = $b;
-        let allocator = $allocator;
         let mut out = $out;
         let size = $size;
 
@@ -45,6 +44,8 @@ macro_rules! bench_trees {
                 ].iter().cloned());
             example = Tree::node_with_forest("aaa", aaas);
         }
+        let allocator = $allocator;
+
         let task = || {
             example.pretty(&allocator).1.render(70, &mut out).unwrap();
         };

--- a/benches/trees.rs
+++ b/benches/trees.rs
@@ -20,26 +20,31 @@ use trees::{
 mod trees;
 
 macro_rules! bench_trees {
-    ($b: expr, $out: expr, $allocator: expr) => {{
+    ($b: expr, $out: expr, $allocator: expr, $size: expr) => {{
+        let arena = Arena::new();
         let b = $b;
         let allocator = $allocator;
         let mut out = $out;
+        let size = $size;
 
-        let bbbbbbs =
-            [ Tree::node("ccc")
-            , Tree::node("dd")
-            ];
-        let ffffs =
-            [ Tree::node("gg")
-            , Tree::node("hhh")
-            , Tree::node("ii")
-            ];
-        let aaas =
-            [ Tree::node_with_forest("bbbbbb", &bbbbbbs)
-            , Tree::node("eee")
-            , Tree::node_with_forest("ffff", &ffffs)
-            ];
-        let example = Tree::node_with_forest("aaa", &aaas);
+        let mut example = Tree::node("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        for _ in 0..size {
+            let bbbbbbs =
+                arena.alloc_extend([ example
+                , Tree::node("dd")
+                ].iter().cloned());
+            let ffffs =
+                arena.alloc_extend([ Tree::node("gg")
+                , Tree::node("hhh")
+                , Tree::node("ii")
+                ].iter().cloned());
+            let aaas =
+                arena.alloc_extend([ Tree::node_with_forest("bbbbbb", bbbbbbs)
+                , Tree::node("eee")
+                , Tree::node_with_forest("ffff", ffffs)
+                ].iter().cloned());
+            example = Tree::node_with_forest("aaa", aaas);
+        }
         let task = || {
             example.pretty(&allocator).1.render(70, &mut out).unwrap();
         };
@@ -49,29 +54,58 @@ macro_rules! bench_trees {
 
 #[bench]
 fn bench_sink_box(b: &mut test::Bencher) -> () {
-    bench_trees!(b, io::sink(), BoxAllocator)
+    bench_trees!(b, io::sink(), BoxAllocator, 1)
 }
 #[bench]
 fn bench_sink_arena(b: &mut test::Bencher) -> () {
-    bench_trees!(b, io::sink(), Arena::new())
+    bench_trees!(b, io::sink(), Arena::new(), 1)
 }
 
 #[bench]
 fn bench_vec_box(b: &mut test::Bencher) -> () {
-    bench_trees!(b, Vec::new(), BoxAllocator)
+    bench_trees!(b, Vec::new(), BoxAllocator, 1)
 }
 #[bench]
 fn bench_vec_arena(b: &mut test::Bencher) -> () {
-    bench_trees!(b, Vec::new(), Arena::new())
+    bench_trees!(b, Vec::new(), Arena::new(), 1)
 }
 
 #[bench]
 fn bench_io_box(b: &mut test::Bencher) -> () {
     let out = tempfile::tempfile().unwrap();
-    bench_trees!(b, io::BufWriter::new(out), BoxAllocator)
+    bench_trees!(b, io::BufWriter::new(out), BoxAllocator, 1)
 }
 #[bench]
 fn bench_io_arena(b: &mut test::Bencher) -> () {
     let out = tempfile::tempfile().unwrap();
-    bench_trees!(b, io::BufWriter::new(out), Arena::new())
+    bench_trees!(b, io::BufWriter::new(out), Arena::new(), 1)
+}
+
+#[bench]
+fn bench_large_sink_box(b: &mut test::Bencher) -> () {
+    bench_trees!(b, io::sink(), BoxAllocator, 50)
+}
+#[bench]
+fn bench_large_sink_arena(b: &mut test::Bencher) -> () {
+    bench_trees!(b, io::sink(), Arena::new(), 50)
+}
+
+#[bench]
+fn bench_large_vec_box(b: &mut test::Bencher) -> () {
+    bench_trees!(b, Vec::new(), BoxAllocator, 50)
+}
+#[bench]
+fn bench_large_vec_arena(b: &mut test::Bencher) -> () {
+    bench_trees!(b, Vec::new(), Arena::new(), 50)
+}
+
+#[bench]
+fn bench_large_io_box(b: &mut test::Bencher) -> () {
+    let out = tempfile::tempfile().unwrap();
+    bench_trees!(b, io::BufWriter::new(out), BoxAllocator, 50)
+}
+#[bench]
+fn bench_large_io_arena(b: &mut test::Bencher) -> () {
+    let out = tempfile::tempfile().unwrap();
+    bench_trees!(b, io::BufWriter::new(out), Arena::new(), 50)
 }

--- a/benches/trees.rs
+++ b/benches/trees.rs
@@ -3,22 +3,28 @@
 extern crate test;
 extern crate pretty;
 extern crate typed_arena;
+extern crate tempfile;
 
-use trees::{
-    Tree,
-};
+use std::io;
 
 use pretty::BoxAllocator;
 
 use typed_arena::Arena;
 
+
+use trees::{
+    Tree,
+};
+
 #[path="../examples/trees.rs"]
 mod trees;
 
 macro_rules! bench_trees {
-    ($b: expr, $allocator: expr) => {{
+    ($b: expr, $out: expr, $allocator: expr) => {{
         let b = $b;
         let allocator = $allocator;
+        let mut out = $out;
+
         let bbbbbbs =
             [ Tree::node("ccc")
             , Tree::node("dd")
@@ -34,7 +40,6 @@ macro_rules! bench_trees {
             , Tree::node_with_forest("ffff", &ffffs)
             ];
         let example = Tree::node_with_forest("aaa", &aaas);
-        let mut out = std::io::sink();
         let task = || {
             example.pretty(&allocator).1.render(70, &mut out).unwrap();
         };
@@ -43,10 +48,30 @@ macro_rules! bench_trees {
 }
 
 #[bench]
-fn bench_box(b: &mut test::Bencher) -> () {
-    bench_trees!(b, BoxAllocator)
+fn bench_sink_box(b: &mut test::Bencher) -> () {
+    bench_trees!(b, io::sink(), BoxAllocator)
 }
 #[bench]
-fn bench_arena(b: &mut test::Bencher) -> () {
-    bench_trees!(b, Arena::new())
+fn bench_sink_arena(b: &mut test::Bencher) -> () {
+    bench_trees!(b, io::sink(), Arena::new())
+}
+
+#[bench]
+fn bench_vec_box(b: &mut test::Bencher) -> () {
+    bench_trees!(b, Vec::new(), BoxAllocator)
+}
+#[bench]
+fn bench_vec_arena(b: &mut test::Bencher) -> () {
+    bench_trees!(b, Vec::new(), Arena::new())
+}
+
+#[bench]
+fn bench_io_box(b: &mut test::Bencher) -> () {
+    let out = tempfile::tempfile().unwrap();
+    bench_trees!(b, io::BufWriter::new(out), BoxAllocator)
+}
+#[bench]
+fn bench_io_arena(b: &mut test::Bencher) -> () {
+    let out = tempfile::tempfile().unwrap();
+    bench_trees!(b, io::BufWriter::new(out), Arena::new())
 }

--- a/examples/trees.rs
+++ b/examples/trees.rs
@@ -21,7 +21,7 @@ impl<'a> Forest<'a> {
         Forest(&[])
     }
 
-    fn bracket<'b, A>(&self, allocator: &'b A) -> DocBuilder<'b, A>
+    fn bracket<'b, A>(&'b self, allocator: &'b A) -> DocBuilder<'b, A>
     where A: Allocator<'b>
     {
         if (self.0).len() == 0 {
@@ -37,7 +37,7 @@ impl<'a> Forest<'a> {
         }
     }
 
-    fn pretty<'b, A>(&self, allocator: &'b A) -> DocBuilder<'b, A>
+    fn pretty<'b, A>(&'b self, allocator: &'b A) -> DocBuilder<'b, A>
     where A: Allocator<'b>
     {
         let forest = self.0;
@@ -83,10 +83,10 @@ impl<'a> Tree<'a> {
         }
     }
 
-    pub fn pretty<'b, A>(&self, allocator: &'b A) -> DocBuilder<'b, A>
+    pub fn pretty<'b, A>(&'b self, allocator: &'b A) -> DocBuilder<'b, A>
     where A: Allocator<'b>
     {
-        allocator.text(self.node.clone())
+        allocator.text(&self.node[..])
             .append((self.forest).bracket(allocator))
             .group()
     }

--- a/examples/trees.rs
+++ b/examples/trees.rs
@@ -2,7 +2,7 @@ extern crate pretty;
 
 use pretty::{
     BoxAllocator,
-    Allocator,
+    DocAllocator,
     DocBuilder,
 };
 use std::io;
@@ -21,7 +21,7 @@ impl<'a> Forest<'a> {
     }
 
     fn bracket<'b, A>(&'b self, allocator: &'b A) -> DocBuilder<'b, A>
-    where A: Allocator<'b>
+    where A: DocAllocator<'b>
     {
         if (self.0).len() == 0 {
             allocator.nil()
@@ -37,7 +37,7 @@ impl<'a> Forest<'a> {
     }
 
     fn pretty<'b, A>(&'b self, allocator: &'b A) -> DocBuilder<'b, A>
-    where A: Allocator<'b>
+    where A: DocAllocator<'b>
     {
         let forest = self.0;
         let mut doc = allocator.nil();
@@ -83,7 +83,7 @@ impl<'a> Tree<'a> {
     }
 
     pub fn pretty<'b, A>(&'b self, allocator: &'b A) -> DocBuilder<'b, A>
-    where A: Allocator<'b>
+    where A: DocAllocator<'b>
     {
         allocator.text(&self.node[..])
             .append((self.forest).bracket(allocator))

--- a/examples/trees.rs
+++ b/examples/trees.rs
@@ -3,7 +3,6 @@ extern crate pretty;
 use pretty::{
     BoxAllocator,
     Allocator,
-    DocAllocator,
     DocBuilder,
 };
 use std::io;

--- a/examples/trees.rs
+++ b/examples/trees.rs
@@ -1,7 +1,10 @@
 extern crate pretty;
 
 use pretty::{
-    Doc
+    BoxAllocator,
+    Allocator,
+    DocAllocator,
+    DocBuilder,
 };
 use std::io;
 use std::str;
@@ -18,35 +21,39 @@ impl<'a> Forest<'a> {
         Forest(&[])
     }
 
-    fn bracket(&self) -> Doc {
+    fn bracket<'b, A>(&self, allocator: &'b A) -> DocBuilder<'b, A>
+    where A: Allocator<'b>
+    {
         if (self.0).len() == 0 {
-            Doc::nil()
+            allocator.nil()
         } else {
-            Doc::text("[")
+            allocator.text("[")
                 .append(
-                    Doc::newline()
-                        .append(self.pretty())
+                    allocator.newline()
+                        .append(self.pretty(allocator))
                         .nest(2))
-                .append(Doc::newline())
-                .append(Doc::text("]"))
+                .append(allocator.newline())
+                .append(allocator.text("]"))
         }
     }
 
-    fn pretty(&self) -> Doc {
+    fn pretty<'b, A>(&self, allocator: &'b A) -> DocBuilder<'b, A>
+    where A: Allocator<'b>
+    {
         let forest = self.0;
-        let mut doc = Doc::nil();
+        let mut doc = allocator.nil();
         let mut i = 0;
         let k = forest.len() - 1;
         loop {
             if i < k {
                 doc = doc
-                    .append(forest[i].pretty()
-                        .append(Doc::text(","))
-                        .append(Doc::newline()));
+                    .append(forest[i].pretty(allocator)
+                        .append(allocator.text(","))
+                        .append(allocator.newline()));
             }
             else if i == k {
                 doc = doc
-                    .append(forest[i].pretty());
+                    .append(forest[i].pretty(allocator));
                 break
             }
             i += 1;
@@ -76,15 +83,18 @@ impl<'a> Tree<'a> {
         }
     }
 
-    pub fn pretty(&self) -> Doc {
-        Doc::text(self.node.clone())
-            .append((self.forest).bracket())
+    pub fn pretty<'b, A>(&self, allocator: &'b A) -> DocBuilder<'b, A>
+    where A: Allocator<'b>
+    {
+        allocator.text(self.node.clone())
+            .append((self.forest).bracket(allocator))
             .group()
     }
 }
 
 #[allow(dead_code)]
 pub fn main() {
+    let allocator = BoxAllocator;
     let bbbbbbs = [
         Tree::node("ccc"),
         Tree::node("dd"),
@@ -108,14 +118,16 @@ pub fn main() {
         print!("\nwriting to stdout directly:\n");
         let mut out = io::stdout();
         example
-            .pretty()
+            .pretty(&allocator)
+            .1
             .render(70, &mut out)
     // try writing to memory
     }.and_then(|()| {
         print!("\nwriting to string then printing:\n");
         let mut mem = Vec::new();
         example
-            .pretty()
+            .pretty(&allocator)
+            .1
             .render(70, &mut mem)
             // print to console from memory
             .map(|()| {

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -21,7 +21,7 @@ enum Mode {
 /// The concrete document type. This type is not meant to be used directly. Instead use the static
 /// functions on `Doc` or the methods on an `Allocator`.
 ///
-/// The `B` paramater is used to abstract over pointers to `Doc`. See `RefDoc` and `BoxDoc` for how
+/// The `B` parameter is used to abstract over pointers to `Doc`. See `RefDoc` and `BoxDoc` for how
 /// it is used
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Doc<'a, B> {
@@ -154,8 +154,7 @@ where B: Deref<Target = Doc<'a, B>>
                         let mut inserted = 0;
                         while inserted < ind {
                             let insert = cmp::min(100, ind - inserted);
-                            inserted += insert;
-                            try!(out.write_all(&SPACES[..insert]));
+                            inserted += try!(out.write(&SPACES[..insert]));
                         }
                     },
                 }

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -55,18 +55,14 @@ fn fitting<'a, B>(
 where B: Deref<Target = Doc<'a, B>>
 {
     let mut bidx = bcmds.len();
-    let mut fits = true;
     fcmds.clear(); // clear from previous calls from best
     fcmds.push(next);
-    loop {
-        if rem < 0 {
-            fits = false;
-            break;
-        }
+    while rem >= 0 {
         match fcmds.pop() {
             None => {
                 if bidx == 0 {
-                    break;
+                    // All commands have been processed
+                    return true;
                 } else {
                     fcmds.push(bcmds[ bidx - 1 ]);
                     bidx -= 1;
@@ -86,7 +82,14 @@ where B: Deref<Target = Doc<'a, B>>
                     fcmds.push((ind + off, mode, doc));
                 },
                 &Newline => {
-                    fits = true;
+                    match mode {
+                        Mode::Flat => {
+                            rem -= 1;
+                        },
+                        Mode::Break => {
+                            return true;
+                        },
+                    }
                 },
                 &Text(ref str) => {
                     rem -= str.len() as isize;
@@ -94,7 +97,7 @@ where B: Deref<Target = Doc<'a, B>>
             }
         }
     }
-    fits
+    false
 }
 
 #[inline]

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -1,3 +1,4 @@
+use std::iter;
 use std::io;
 use std::ops::Deref;
 
@@ -9,19 +10,6 @@ pub use self::Doc::{
     Newline,
     Text,
 };
-
-#[inline]
-fn spaces(n: usize) -> String {
-    use std::iter;
-    iter::repeat(' ').take(n).collect()
-}
-
-#[inline]
-fn spaces_then_newline(n: usize) -> String {
-    let mut s = String::from("\n");
-    s.push_str(&spaces(n));
-    s
-}
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 enum Mode {
@@ -143,7 +131,9 @@ where B: Deref<Target = Doc<'a, B>>
                     bcmds.push((ind + off, mode, doc));
                 },
                 &Newline => {
-                    try!(out.write_all(spaces_then_newline(ind).as_bytes()));
+                    for b in iter::once(b'\n').chain(iter::repeat(b' ').take(ind)) {
+                        try!(out.write_all(&[b]));
+                    }
                     pos = ind;
                 },
                 &Text(ref s) => {

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -19,7 +19,7 @@ enum Mode {
 }
 
 /// The concrete document type. This type is not meant to be used directly. Instead use the static
-/// functions on `Doc` or the methods on an `Allocator`.
+/// functions on `Doc` or the methods on an `DocAllocator`.
 ///
 /// The `B` parameter is used to abstract over pointers to `Doc`. See `RefDoc` and `BoxDoc` for how
 /// it is used

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -18,6 +18,11 @@ enum Mode {
     Flat,
 }
 
+/// The concrete document type. This type is not meant to be used directly. Instead use the static
+/// functions on `Doc` or the methods on an `Allocator`.
+///
+/// The `B` paramater is used to abstract over pointers to `Doc`. See `RefDoc` and `BoxDoc` for how
+/// it is used
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Doc<'a, B> {
     Nil,
@@ -35,6 +40,8 @@ impl<'a, B, S> From<S> for Doc<'a, B> where S: Into<Cow<'a, str>> {
 }
 
 impl<'a, B> Doc<'a, B> {
+
+    /// Writes a rendered document.
     #[inline]
     pub fn render<'b, W: ?Sized + io::Write>(&'b self, width: usize, out: &mut W) -> io::Result<()>
     where B: Deref<Target = Doc<'b, B>>

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -127,13 +127,20 @@ where B: Deref<Target = Doc<'a, B>>
                 bcmds.push((ind + off, mode, doc));
             },
             &Newline => {
-                const SPACES: [u8; 100] = [b' '; 100];
-                try!(out.write_all(b"\n"));
-                let mut inserted = 0;
-                while inserted < ind {
-                    let insert = cmp::min(100, ind - inserted);
-                    inserted += insert;
-                    try!(out.write_all(&SPACES[..insert]));
+                match mode {
+                    Mode::Flat => {
+                        try!(out.write_all(b" "));
+                    },
+                    Mode::Break => {
+                        const SPACES: [u8; 100] = [b' '; 100];
+                        try!(out.write_all(b"\n"));
+                        let mut inserted = 0;
+                        while inserted < ind {
+                            let insert = cmp::min(100, ind - inserted);
+                            inserted += insert;
+                            try!(out.write_all(&SPACES[..insert]));
+                        }
+                    },
                 }
                 pos = ind;
             },

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use std::cmp;
 use std::io;
 use std::ops::Deref;
 
@@ -131,8 +131,13 @@ where B: Deref<Target = Doc<'a, B>>
                     bcmds.push((ind + off, mode, doc));
                 },
                 &Newline => {
-                    for b in iter::once(b'\n').chain(iter::repeat(b' ').take(ind)) {
-                        try!(out.write_all(&[b]));
+                    const SPACES: [u8; 100] = [b' '; 100];
+                    try!(out.write_all(b"\n"));
+                    let mut inserted = 0;
+                    while inserted < ind {
+                        let insert = cmp::min(100, ind - inserted);
+                        inserted += insert;
+                        try!(out.write_all(&SPACES[..insert]));
                     }
                     pos = ind;
                 },

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp;
 use std::io;
 use std::ops::Deref;
@@ -24,7 +25,13 @@ pub enum Doc<'a, B> {
     Group(B),
     Nest(usize, B),
     Newline,
-    Text(::std::borrow::Cow<'a, str>),
+    Text(Cow<'a, str>),
+}
+
+impl<'a, B, S> From<S> for Doc<'a, B> where S: Into<Cow<'a, str>> {
+    fn from(s: S) -> Doc<'a, B> {
+        Doc::Text(s.into())
+    }
 }
 
 impl<'a, B> Doc<'a, B> {

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -36,7 +36,7 @@ impl<'a, B, S> From<S> for Doc<'a, B> where S: Into<Cow<'a, str>> {
 
 impl<'a, B> Doc<'a, B> {
     #[inline]
-    pub fn render<'b, W: io::Write>(&'b self, width: usize, out: &mut W) -> io::Result<()>
+    pub fn render<'b, W: ?Sized + io::Write>(&'b self, width: usize, out: &mut W) -> io::Result<()>
     where B: Deref<Target = Doc<'b, B>>
     {
         best(self, width, out).and_then(|()| out.write_all(b"\n"))
@@ -101,7 +101,7 @@ where B: Deref<Target = Doc<'a, B>>
 }
 
 #[inline]
-pub fn best<'a, W: io::Write, B>(
+pub fn best<'a, W: ?Sized + io::Write, B>(
     doc: &'a Doc<'a, B>,
     width: usize,
     out: &mut W,

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -39,6 +39,15 @@ pub enum Doc<'a, B> {
     Text(::std::borrow::Cow<'a, str>),
 }
 
+impl<'a, B> Doc<'a, B> {
+    #[inline]
+    pub fn render<'b, W: io::Write>(&'b self, width: usize, out: &mut W) -> io::Result<()>
+    where B: Deref<Target = Doc<'b, B>>
+    {
+        best(self, width, out).and_then(|()| out.write_all(b"\n"))
+    }
+}
+
 type Cmd<'a, B> = (usize, Mode, &'a Doc<'a, B>);
 
 #[inline]

--- a/src/pretty/lib.rs
+++ b/src/pretty/lib.rs
@@ -209,3 +209,18 @@ impl<'a> Doc<'a, BoxDoc<'a>> {
         DocBuilder(&BOX_ALLOCATOR, self).nest(offset).into()
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::from_utf8;
+
+    #[test]
+    fn box_doc_inference() {
+        let doc = Doc::group(Doc::text("test").append(Doc::newline()).append(Doc::text("test")));
+        let mut vec = Vec::new();
+        doc.render(70, &mut vec).unwrap();
+        assert_eq!(from_utf8(&vec).unwrap(), "test test\n");
+    }
+}

--- a/src/pretty/lib.rs
+++ b/src/pretty/lib.rs
@@ -27,6 +27,12 @@ pub type Doc<'a, B> = doc::Doc<'a, B>;
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct BoxDoc<'a>(Box<doc::Doc<'a, BoxDoc<'a>>>);
 
+impl<'a> BoxDoc<'a> {
+    fn new(doc: doc::Doc<'a, BoxDoc<'a>>) -> BoxDoc<'a> {
+        BoxDoc(Box::new(doc))
+    }
+}
+
 impl<'a> Deref for BoxDoc<'a> {
     type Target = doc::Doc<'a, BoxDoc<'a>>;
     
@@ -156,14 +162,13 @@ impl<'a> Allocator<'a> for BoxAllocator {
     type Doc = BoxDoc<'a>;
     
     fn alloc(&'a self, doc: doc::Doc<'a, Self::Doc>) -> Self::Doc {
-        BoxDoc(Box::new(doc))
+        BoxDoc::new(doc)
     }
 }
-
 impl<'a> BoxDoc<'a> {
     #[inline]
     pub fn nil() -> BoxDoc<'a> {
-        BoxDoc(Box::new(Nil))
+        BoxDoc::new(Nil)
     }
 
     #[inline]
@@ -172,7 +177,7 @@ impl<'a> BoxDoc<'a> {
             &Nil  => that,
             _ => match &*that {
                 &Nil  => self,
-                _ => BoxDoc(Box::new(Append(self, that))),
+                _ => BoxDoc::new(Append(self, that)),
             }
         }
     }
@@ -189,17 +194,17 @@ impl<'a> BoxDoc<'a> {
 
     #[inline]
     pub fn group(self) -> BoxDoc<'a> {
-        BoxDoc(Box::new(Group(self)))
+        BoxDoc::new(Group(self))
     }
 
     #[inline]
     pub fn nest(self, offset: usize) -> BoxDoc<'a> {
-        BoxDoc(Box::new(Nest(offset, self)))
+        BoxDoc::new(Nest(offset, self))
     }
 
     #[inline]
     pub fn newline() -> BoxDoc<'a> {
-        BoxDoc(Box::new(Newline))
+        BoxDoc::new(Newline)
     }
 
     #[inline]
@@ -210,6 +215,6 @@ impl<'a> BoxDoc<'a> {
 
     #[inline]
     pub fn text<T: Into<Cow<'a, str>>>(data: T) -> BoxDoc<'a> {
-        BoxDoc(Box::new(Text(data.into())))
+        BoxDoc::new(Text(data.into()))
     }
 }

--- a/src/pretty/lib.rs
+++ b/src/pretty/lib.rs
@@ -14,8 +14,6 @@ use doc::Doc::{
 use std::borrow::Cow;
 use std::ops::Deref;
 
-use typed_arena::Arena;
-
 mod doc;
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -122,8 +120,10 @@ impl<'a> Deref for RefDoc<'a> {
     }
 }
 
+pub type Arena<'a> = typed_arena::Arena<doc::Doc<'a, RefDoc<'a>>>;
 
-impl<'a> Allocator<'a> for Arena<doc::Doc<'a, RefDoc<'a>>> {
+
+impl<'a> Allocator<'a> for Arena<'a> {
     type Doc = RefDoc<'a>;
     
     fn alloc(&'a self, doc: doc::Doc<'a, Self::Doc>) -> Self::Doc {

--- a/src/pretty/lib.rs
+++ b/src/pretty/lib.rs
@@ -1,6 +1,7 @@
 //! This crate defines a
 //! [Wadler-style](http://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf)
 //! pretty-printing API.
+extern crate typed_arena;
 
 use doc::{
     best,
@@ -17,69 +18,198 @@ use std::io;
 use std::borrow::Cow;
 use std::ops::Deref;
 
+use typed_arena::Arena;
+
 mod doc;
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub struct Doc<'a>(Box<doc::Doc<'a, Doc<'a>>>);
+pub type Doc<'a, B> = doc::Doc<'a, B>;
 
-impl<'a> Deref for Doc<'a> {
-    type Target = doc::Doc<'a, Doc<'a>>;
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct BoxDoc<'a>(Box<doc::Doc<'a, BoxDoc<'a>>>);
+
+impl<'a> Deref for BoxDoc<'a> {
+    type Target = doc::Doc<'a, BoxDoc<'a>>;
     
-    fn deref(&self) -> &doc::Doc<'a, Doc<'a>> {
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> Doc<'a> {
+pub struct DocBuilder<'a, A: ?Sized>(pub &'a A, pub doc::Doc<'a, A::Doc>)
+    where A: Allocator<'a> + 'a;
+
+impl <'a, A> Into<doc::Doc<'a, A::Doc>> for DocBuilder<'a, A>
+    where A: Allocator<'a>
+{
+    fn into(self) -> doc::Doc<'a, A::Doc> {
+        self.1
+    }
+}
+
+pub trait Allocator<'a> {
+    type Doc: Deref<Target = doc::Doc<'a, Self::Doc>> + Clone;
+    fn alloc(&'a self, doc::Doc<'a, Self::Doc>) -> Self::Doc;
+
     #[inline]
-    pub fn nil() -> Doc<'a> {
-        Doc(Box::new(Nil))
+    fn nil(&'a self) -> DocBuilder<'a, Self> {
+        DocBuilder(self, Nil)
     }
 
     #[inline]
-    pub fn append(self, that: Doc<'a>) -> Doc<'a> {
+    fn newline(&'a self) -> DocBuilder<'a, Self> {
+        DocBuilder(self, Newline)
+    }
+
+    #[inline]
+    fn as_string<T: ToString>(&'a self, t: T) -> DocBuilder<'a, Self> {
+        self.text(t.to_string())
+    }
+
+    #[inline]
+    fn text<T: Into<Cow<'a, str>>>(&'a self, data: T) -> DocBuilder<'a, Self> {
+        DocBuilder(self, Text(data.into()))
+    }
+
+    #[inline]
+    fn concat(&'a self, docs: &[doc::Doc<'a, Self::Doc>]) -> DocBuilder<'a, Self> {
+        docs.iter().cloned().fold(self.nil(), |a, b| a.append(b))
+    }
+}
+
+
+pub trait DocAllocator<'a> : Sized + 'a {
+    type Allocator: ?Sized + Allocator<'a>;
+    type Doc: Deref<Target = doc::Doc<'a, Self::Doc>> + Clone;
+
+    #[inline]
+    fn split(self) -> DocBuilder<'a, Self::Allocator>;
+
+    #[inline]
+    fn append<B>(self, that: B) -> DocBuilder<'a, Self::Allocator>
+    where B: Into<doc::Doc<'a, Self::Doc>>,
+          Self::Allocator: Allocator<'a, Doc = Self::Doc>,
+    {
+        let DocBuilder(allocator, this) = self.split();
+        let that = that.into();
+        let doc = match this {
+            Nil  => that,
+            _ => match that {
+                Nil  => this,
+                _ => Append(allocator.alloc(this), allocator.alloc(that)),
+            }
+        };
+        DocBuilder(allocator, doc)
+    }
+
+    #[inline]
+    fn group(self) -> DocBuilder<'a, Self::Allocator>
+    where Self::Allocator: Allocator<'a, Doc = Self::Doc>,
+    {
+        let DocBuilder(allocator, this) = self.split();
+        DocBuilder(allocator, Group(allocator.alloc(this)))
+    }
+
+    #[inline]
+    fn nest(self, offset: usize) -> DocBuilder<'a, Self::Allocator>
+    where Self::Allocator: Allocator<'a, Doc = Self::Doc>,
+    {
+        let DocBuilder(allocator, this) = self.split();
+        DocBuilder(allocator, Nest(offset, allocator.alloc(this)))
+    }
+}
+
+impl<'a, A: ?Sized> DocAllocator<'a> for DocBuilder<'a, A>
+where A: Allocator<'a>
+{
+    type Allocator = A;
+    type Doc = A::Doc;
+
+    #[inline]
+    fn split(self) -> DocBuilder<'a, Self::Allocator> {
+        self
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct RefDoc<'a>(&'a doc::Doc<'a, RefDoc<'a>>);
+
+impl<'a> Deref for RefDoc<'a> {
+    type Target = doc::Doc<'a, RefDoc<'a>>;
+    
+    fn deref(&self) -> &doc::Doc<'a, RefDoc<'a>> {
+        &self.0
+    }
+}
+
+
+impl<'a> Allocator<'a> for Arena<doc::Doc<'a, RefDoc<'a>>> {
+    type Doc = RefDoc<'a>;
+    
+    fn alloc(&'a self, doc: doc::Doc<'a, Self::Doc>) -> Self::Doc {
+        RefDoc(Arena::alloc(self, doc))
+    }
+}
+
+pub struct BoxAllocator;
+
+impl<'a> Allocator<'a> for BoxAllocator {
+    type Doc = BoxDoc<'a>;
+    
+    fn alloc(&'a self, doc: doc::Doc<'a, Self::Doc>) -> Self::Doc {
+        BoxDoc(Box::new(doc))
+    }
+}
+
+impl<'a> BoxDoc<'a> {
+    #[inline]
+    pub fn nil() -> BoxDoc<'a> {
+        BoxDoc(Box::new(Nil))
+    }
+
+    #[inline]
+    pub fn append(self, that: BoxDoc<'a>) -> BoxDoc<'a> {
         match &*self {
             &Nil  => that,
             _ => match &*that {
                 &Nil  => self,
-                _ => Doc(Box::new(Append(self, that))),
+                _ => BoxDoc(Box::new(Append(self, that))),
             }
         }
     }
 
     #[inline]
-    pub fn as_string<T: ToString>(t: T) -> Doc<'a> {
-        Doc::text(t.to_string())
+    pub fn as_string<T: ToString>(t: T) -> BoxDoc<'a> {
+        BoxDoc::text(t.to_string())
     }
 
     #[inline]
-    pub fn concat(docs: &[Doc<'a>]) -> Doc<'a> {
-        docs.iter().fold(Doc::nil(), |a, b| a.append(b.clone()))
+    pub fn concat(docs: &[BoxDoc<'a>]) -> BoxDoc<'a> {
+        docs.iter().fold(BoxDoc::nil(), |a, b| a.append(b.clone()))
     }
 
     #[inline]
-    pub fn group(self) -> Doc<'a> {
-        Doc(Box::new(Group(self)))
+    pub fn group(self) -> BoxDoc<'a> {
+        BoxDoc(Box::new(Group(self)))
     }
 
     #[inline]
-    pub fn nest(self, offset: usize) -> Doc<'a> {
-        Doc(Box::new(Nest(offset, self)))
+    pub fn nest(self, offset: usize) -> BoxDoc<'a> {
+        BoxDoc(Box::new(Nest(offset, self)))
     }
 
     #[inline]
-    pub fn newline() -> Doc<'a> {
-        Doc(Box::new(Newline))
+    pub fn newline() -> BoxDoc<'a> {
+        BoxDoc(Box::new(Newline))
     }
 
     #[inline]
     pub fn render<W: io::Write>(&self, width: usize, out: &mut W) -> io::Result<()> {
-        let &Doc(ref doc) = self;
+        let &BoxDoc(ref doc) = self;
         best(doc, width, out).and_then(|()| out.write_all(b"\n"))
     }
 
     #[inline]
-    pub fn text<T: Into<Cow<'a, str>>>(data: T) -> Doc<'a> {
-        Doc(Box::new(Text(data.into())))
+    pub fn text<T: Into<Cow<'a, str>>>(data: T) -> BoxDoc<'a> {
+        BoxDoc(Box::new(Text(data.into())))
     }
 }

--- a/src/pretty/lib.rs
+++ b/src/pretty/lib.rs
@@ -12,12 +12,19 @@ use doc::Doc::{
     Text,
 };
 use std::borrow::Cow;
+use std::fmt;
 use std::ops::Deref;
 
 mod doc;
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub struct BoxDoc<'a>(Box<doc::Doc<'a, BoxDoc<'a>>>);
+
+impl<'a> fmt::Debug for BoxDoc<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl<'a> BoxDoc<'a> {
     fn new(doc: doc::Doc<'a, BoxDoc<'a>>) -> BoxDoc<'a> {
@@ -109,8 +116,14 @@ impl<'a, 's, A: ?Sized> DocBuilder<'a, A> where A: Allocator<'a> {
     }
 }
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub struct RefDoc<'a>(&'a doc::Doc<'a, RefDoc<'a>>);
+
+impl<'a> fmt::Debug for RefDoc<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl<'a> Deref for RefDoc<'a> {
     type Target = doc::Doc<'a, RefDoc<'a>>;

--- a/src/pretty/lib.rs
+++ b/src/pretty/lib.rs
@@ -43,7 +43,7 @@ impl<'a> Deref for BoxDoc<'a> {
 pub struct DocBuilder<'a, A: ?Sized>(pub &'a A, pub doc::Doc<'a, A::Doc>)
     where A: Allocator<'a> + 'a;
 
-impl <'a, A> Into<doc::Doc<'a, A::Doc>> for DocBuilder<'a, A>
+impl <'a, A: ?Sized> Into<doc::Doc<'a, A::Doc>> for DocBuilder<'a, A>
     where A: Allocator<'a>
 {
     fn into(self) -> doc::Doc<'a, A::Doc> {

--- a/src/pretty/lib.rs
+++ b/src/pretty/lib.rs
@@ -164,20 +164,32 @@ impl<'a> DocAllocator<'a> for BoxAllocator {
 
 pub use doc::Doc;
 
-impl<'a> Doc<'a, BoxDoc<'a>> {
+impl<'a, B> Doc<'a, B> {
     #[inline]
-    pub fn nil() -> Doc<'a, BoxDoc<'a>> {
+    pub fn nil() -> Doc<'a, B> {
         Nil
     }
 
     #[inline]
-    pub fn append(self, that: Doc<'a, BoxDoc<'a>>) -> Doc<'a, BoxDoc<'a>> {
-        DocBuilder(&BOX_ALLOCATOR, self).append(that).into()
+    pub fn as_string<T: ToString>(t: T) -> Doc<'a, B> {
+        Doc::text(t.to_string())
     }
 
     #[inline]
-    pub fn as_string<T: ToString>(t: T) -> Doc<'a, BoxDoc<'a>> {
-        Doc::text(t.to_string())
+    pub fn newline() -> Doc<'a, B> {
+        Newline
+    }
+
+    #[inline]
+    pub fn text<T: Into<Cow<'a, str>>>(data: T) -> Doc<'a, B> {
+        Text(data.into())
+    }
+}
+
+impl<'a> Doc<'a, BoxDoc<'a>> {
+    #[inline]
+    pub fn append(self, that: Doc<'a, BoxDoc<'a>>) -> Doc<'a, BoxDoc<'a>> {
+        DocBuilder(&BOX_ALLOCATOR, self).append(that).into()
     }
 
     #[inline]
@@ -195,15 +207,5 @@ impl<'a> Doc<'a, BoxDoc<'a>> {
     #[inline]
     pub fn nest(self, offset: usize) -> Doc<'a, BoxDoc<'a>> {
         DocBuilder(&BOX_ALLOCATOR, self).nest(offset).into()
-    }
-
-    #[inline]
-    pub fn newline() -> Doc<'a, BoxDoc<'a>> {
-        Newline
-    }
-
-    #[inline]
-    pub fn text<T: Into<Cow<'a, str>>>(data: T) -> Doc<'a, BoxDoc<'a>> {
-        Text(data.into())
     }
 }

--- a/src/pretty/lib.rs
+++ b/src/pretty/lib.rs
@@ -77,8 +77,10 @@ pub trait Allocator<'a> {
     }
 
     #[inline]
-    fn concat(&'a self, docs: &[doc::Doc<'a, Self::Doc>]) -> DocBuilder<'a, Self> {
-        docs.iter().cloned().fold(self.nil(), |a, b| a.append(b))
+    fn concat<I>(&'a self, docs: I) -> DocBuilder<'a, Self>
+    where I: IntoIterator<Item = doc::Doc<'a, Self::Doc>>
+    {
+        docs.into_iter().fold(self.nil(), |a, b| a.append(b))
     }
 }
 
@@ -167,8 +169,10 @@ impl<'a> BoxDoc<'a> {
     }
 
     #[inline]
-    pub fn concat(docs: &[BoxDoc<'a>]) -> BoxDoc<'a> {
-        docs.iter().fold(BoxDoc::nil(), |a, b| a.append(b.clone()))
+    pub fn concat<I>(&'a self, docs: I) -> BoxDoc<'a>
+    where I: IntoIterator<Item = BoxDoc<'a>>
+    {
+        docs.into_iter().fold(BoxDoc::nil(), |a, b| a.append(b))
     }
 
     #[inline]


### PR DESCRIPTION
This PR changes the way documents are created to allow them to be created with an Arena from [typed_arena](https://github.com/SimonSapin/rust-typed-arena). By using an Arena instead of `Box` pretty printing (creation of Docs + writing the Docs) can get a speedup of up to 2x (see benchmarks).

Some bug fixes and ergonomic improvements are also included, see individual commits for details.