### PR TITLE
Add quick start documentation. Fixes #26.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/freebroccolo/pretty.rs"
 
 [lib]
 doc = true
-doctest = false
+doctest = true
 name = "pretty"
 path = "src/pretty/lib.rs"
 

--- a/examples/trees.rs
+++ b/examples/trees.rs
@@ -40,24 +40,8 @@ impl<'a> Forest<'a> {
     where A: DocAllocator<'b>
     {
         let forest = self.0;
-        let mut doc = allocator.nil();
-        let mut i = 0;
-        let k = forest.len() - 1;
-        loop {
-            if i < k {
-                doc = doc
-                    .append(forest[i].pretty(allocator)
-                        .append(allocator.text(","))
-                        .append(allocator.newline()));
-            }
-            else if i == k {
-                doc = doc
-                    .append(forest[i].pretty(allocator));
-                break
-            }
-            i += 1;
-        }
-        doc
+        let separator = allocator.text(",").append(allocator.newline());
+        allocator.intersperse(forest.into_iter().map(|tree| tree.pretty(allocator)), separator)
     }
 }
 


### PR DESCRIPTION
This is by no means complete, but it should help get a new user up and
running quickly.  Please feel free to edit for tone and content.

Locally, the "Quick start" and "Advanced usage" headers do not render
correctly, but I see other examples with this syntax that do render
correctly on crates.io.  I can't explain this.