### PR TITLE
feat: Allow documents to be rendered directly to std::fmt::Write instances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pretty"
-version = "0.2.0"
+version = "0.3.0"
 authors = [ "Jonathan Sterling <jon@jonmsterling.com>", "Darin Morrison <darinmorrison+git@gmail.com>" ]
 description = "Wadler-style pretty-printing combinators in Rust"
 documentation = "http://freebroccolo.github.io/pretty.rs/doc/pretty/"

--- a/examples/trees.rs
+++ b/examples/trees.rs
@@ -1,10 +1,6 @@
 extern crate pretty;
 
-use pretty::{
-    BoxAllocator,
-    DocAllocator,
-    DocBuilder,
-};
+use pretty::{BoxAllocator, DocAllocator, DocBuilder};
 use std::io;
 use std::str;
 
@@ -21,27 +17,30 @@ impl<'a> Forest<'a> {
     }
 
     fn bracket<'b, A>(&'b self, allocator: &'b A) -> DocBuilder<'b, A>
-    where A: DocAllocator<'b>
+    where
+        A: DocAllocator<'b>,
     {
         if (self.0).len() == 0 {
             allocator.nil()
         } else {
-            allocator.text("[")
-                .append(
-                    allocator.newline()
-                        .append(self.pretty(allocator))
-                        .nest(2))
+            allocator
+                .text("[")
+                .append(allocator.newline().append(self.pretty(allocator)).nest(2))
                 .append(allocator.newline())
                 .append(allocator.text("]"))
         }
     }
 
     fn pretty<'b, A>(&'b self, allocator: &'b A) -> DocBuilder<'b, A>
-    where A: DocAllocator<'b>
+    where
+        A: DocAllocator<'b>,
     {
         let forest = self.0;
         let separator = allocator.text(",").append(allocator.newline());
-        allocator.intersperse(forest.into_iter().map(|tree| tree.pretty(allocator)), separator)
+        allocator.intersperse(
+            forest.into_iter().map(|tree| tree.pretty(allocator)),
+            separator,
+        )
     }
 }
 
@@ -67,9 +66,11 @@ impl<'a> Tree<'a> {
     }
 
     pub fn pretty<'b, A>(&'b self, allocator: &'b A) -> DocBuilder<'b, A>
-    where A: DocAllocator<'b>
+    where
+        A: DocAllocator<'b>,
     {
-        allocator.text(&self.node[..])
+        allocator
+            .text(&self.node[..])
             .append((self.forest).bracket(allocator))
             .group()
     }
@@ -78,15 +79,8 @@ impl<'a> Tree<'a> {
 #[allow(dead_code)]
 pub fn main() {
     let allocator = BoxAllocator;
-    let bbbbbbs = [
-        Tree::node("ccc"),
-        Tree::node("dd"),
-    ];
-    let ffffs = [
-        Tree::node("gg"),
-        Tree::node("hhh"),
-        Tree::node("ii"),
-    ];
+    let bbbbbbs = [Tree::node("ccc"), Tree::node("dd")];
+    let ffffs = [Tree::node("gg"), Tree::node("hhh"), Tree::node("ii")];
     let aaas = [
         Tree::node_with_forest("bbbbbb", &bbbbbbs),
         Tree::node("eee"),

--- a/src/pretty/doc.rs
+++ b/src/pretty/doc.rs
@@ -28,7 +28,8 @@ pub enum Doc<'a, B> {
 }
 
 impl<'a, B, S> From<S> for Doc<'a, B>
-    where S: Into<Cow<'a, str>>
+where
+    S: Into<Cow<'a, str>>,
 {
     fn from(s: S) -> Doc<'a, B> {
         Doc::Text(s.into())
@@ -39,7 +40,8 @@ impl<'a, B> Doc<'a, B> {
     /// Writes a rendered document.
     #[inline]
     pub fn render<'b, W: ?Sized + io::Write>(&'b self, width: usize, out: &mut W) -> io::Result<()>
-        where B: Deref<Target = Doc<'b, B>>
+    where
+        B: Deref<Target = Doc<'b, B>>,
     {
         best(self, width, out)
     }
@@ -63,12 +65,14 @@ fn write_spaces<W: ?Sized + io::Write>(spaces: usize, out: &mut W) -> io::Result
 }
 
 #[inline]
-fn fitting<'a, B>(next: Cmd<'a, B>,
-                  bcmds: &Vec<Cmd<'a, B>>,
-                  fcmds: &mut Vec<Cmd<'a, B>>,
-                  mut rem: isize)
-                  -> bool
-    where B: Deref<Target = Doc<'a, B>>
+fn fitting<'a, B>(
+    next: Cmd<'a, B>,
+    bcmds: &Vec<Cmd<'a, B>>,
+    fcmds: &mut Vec<Cmd<'a, B>>,
+    mut rem: isize,
+) -> bool
+where
+    B: Deref<Target = Doc<'a, B>>,
 {
     let mut bidx = bcmds.len();
     fcmds.clear(); // clear from previous calls from best
@@ -127,11 +131,13 @@ fn fitting<'a, B>(next: Cmd<'a, B>,
 }
 
 #[inline]
-pub fn best<'a, W: ?Sized + io::Write, B>(doc: &'a Doc<'a, B>,
-                                          width: usize,
-                                          out: &mut W)
-                                          -> io::Result<()>
-    where B: Deref<Target = Doc<'a, B>>
+pub fn best<'a, W: ?Sized + io::Write, B>(
+    doc: &'a Doc<'a, B>,
+    width: usize,
+    out: &mut W,
+) -> io::Result<()>
+where
+    B: Deref<Target = Doc<'a, B>>,
 {
     let mut pos = 0usize;
     let mut bcmds = vec![(0usize, Mode::Break, doc)];

--- a/src/pretty/lib.rs
+++ b/src/pretty/lib.rs
@@ -463,13 +463,12 @@ impl<'a> Doc<'a, BoxDoc<'a>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::from_utf8;
 
     macro_rules! test {
         ($size: expr, $actual: expr, $expected: expr) => {
-            let mut vec = Vec::new();
-            $actual.render($size, &mut vec).unwrap();
-            assert_eq!(from_utf8(&vec).unwrap(), $expected);
+            let mut s = String::new();
+            $actual.render_fmt($size, &mut s).unwrap();
+            assert_eq!(s, $expected);
         };
         ($actual: expr, $expected: expr) => {
             test!(70, $actual, $expected)


### PR DESCRIPTION
This makes it possible render documents inside fmt::Display implementations without using an intermediate buffer.