### PR TITLE
Bump unicode-width to version 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ features = ["termcolor"]
 arrayvec = "0.5"
 typed-arena = "2.0.0"
 termcolor = { version = "1.1.0", optional = true }
-unicode-width = "0.1"
+unicode-width = "0.2"
 
 [dev-dependencies]
 criterion = "0.4"


### PR DESCRIPTION
Eliminates a copy of `unicode-width` from our dependency tree. Does not appear to increase the rlib size at all.